### PR TITLE
fix(build.yml/vf2): remove exist patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,18 +78,6 @@ jobs:
       - name: "Compile kernel"
         run: |
           pushd kernel
-            # fix vf2
-            if [[ ${{ matrix.board }} = 'visionfive2' ]]; then
-              wget https://github.com/starfive-tech/linux/commit/2f75442523e4b44bdea4ae5bc2e95137d0303c8b.patch 
-              git am 2f75442523e4b44bdea4ae5bc2e95137d0303c8b.patch
-              rm 2f75442523e4b44bdea4ae5bc2e95137d0303c8b.patch
-
-              # timeout x 2
-              # wget https://github.com/Rabenda/linux-starfive/commit/123b7009d4e1daed15a60a67863bee9ee1a2fd66.patch
-              # git am 123b7009d4e1daed15a60a67863bee9ee1a2fd66.patch
-              # rm 123b7009d4e1daed15a60a67863bee9ee1a2fd66.patch
-            fi
-
             # fix unmatched
             if [[ ${{ matrix.board }} = 'unmatched' ]]; then
               wget https://salsa.debian.org/kernel-team/linux/-/raw/master/debian/config/riscv64/config


### PR DESCRIPTION
patch is exist:
https://github.com/starfive-tech/linux/commit/5cd27e82dc6fcd1a847e75f06261f40ce26e67d8

ci run error:
~/work/deepin-riscv-kernel/deepin-riscv-kernel/kernel ~/work/deepin-riscv-kernel/deepin-riscv-kernel --2023-04-06 02:33:20--  https://github.com/starfive-tech/linux/commit/2f75442523e4b44bdea4ae5bc2e95137d0303c8b.patch Resolving github.com (github.com)... 140.82.113.4
Connecting to github.com (github.com)|140.82.113.4|:443... connected. HTTP request sent, awaiting response... 200 OK
Length: 1105 (1.1K) [text/plain]
Saving to: ‘2f75442523e4b44bdea4ae5bc2e95137d0303c8b.patch’

     0K .                                                     100% 27.1M=0s

2023-04-06 02:33:20 (27.1 MB/s) - ‘2f75442523e4b44bdea4ae5bc2e95137d0303c8b.patch’ saved [1105/1105]

error: patch failed: arch/riscv/Makefile:52
Applying: fix: Error unrecognized opcode `csrr a5,0xc01 Patch failed at 0001 fix: Error unrecognized opcode `csrr a5,0xc01 When you have resolved this problem, run "git am --continue". If you prefer to skip this patch, run "git am --skip" instead. To restore the original branch and stop patching, run "git am --abort". error: arch/riscv/Makefile: patch does not apply
hint: Use 'git am --show-current-patch=diff' to see the failed patch Error: Process completed with exit code 128.